### PR TITLE
Map Demo Upgrade: use SRV & TXT records

### DIFF
--- a/demo/dohjs_helpers.js
+++ b/demo/dohjs_helpers.js
@@ -1,0 +1,62 @@
+/// DoHjs Helper Functions
+///
+/// These functions help getting the values from binary wireformat
+/// which are not yet handled by DoHjs.
+
+/// Uint32 helper Class for byte conversion
+class Uint32
+{
+    constructor(Value) 
+    {
+        this.Number = new Uint32Array(1);
+        this.Number[0] = Value;
+    }
+    get Get() 
+    {
+        return this.Number[0];
+    }
+    set Set(newValue) 
+    {
+        this.Number[0] = newValue;
+    }
+};
+
+/// Convert u8 Byte array from network byte order (big-endian) to 32bit unsigned integer (little-endian)
+function ntoh_Uint32 (Source_Byte_Array, Start_Position)
+{
+    var Uint32_Num = new Uint32(0);
+    var Multiplier = 1;
+    for (let i = 3; i >= 0; i--)
+    {
+        Uint32_Num.Set = Uint32_Num.Get + Source_Byte_Array[Start_Position + i] * Multiplier;
+        Multiplier = Multiplier * 256;
+    }
+    return (Uint32_Num.Get);
+}
+
+/// LOC Wireformat Decoder
+class LocDecoder
+{
+    /// constructor takes the raw wireformat bytes array
+    constructor(wire_data) 
+    {
+        this.data = wire_data;
+        this.latitude = this.get_latitude();
+        this.longitude = this.get_longitude();
+    }
+
+    /// get latitude
+    get_latitude() {
+        let latitude_raw = ntoh_Uint32(this.data, 4);
+        let latitude = (latitude_raw - 2147483648.0) / 3600000;
+        return latitude;
+    }
+
+    /// get longitude
+    get_longitude() {
+        let longitude_raw = ntoh_Uint32(this.data, 8);
+        let longitude = (longitude_raw - 2147483648.0) / 3600000;
+        return longitude;
+    }
+
+}

--- a/demo/map.html
+++ b/demo/map.html
@@ -9,6 +9,7 @@
     <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin=""></script>
 	<script src="https://cdn.jsdelivr.net/npm/dohjs@latest/dist/doh.min.js"></script>
     <script src="dohjs_helpers.js"></script>
+    <script src="map.js"></script>
     <style>
 		html, body {
 			height: 100%;
@@ -41,132 +42,8 @@
         const resolver = new doh.DohResolver('https://1.1.1.1/dns-query');
         // const resolver = new doh.DohResolver('https://zembla.zenr.io/dns-query');
 
-        // -------------------------------------------------------
-
-        /// Receive Service Pointers
-        function get_service_pointers (domain) {
-            var query_domain = "_loc._udp." + domain;
-
-            console.log("PTR records of " + query_domain);
-
-            resolver.query(query_domain, 'PTR')
-                .then(response => {
-                    response.answers.forEach(ans => {
-                        console.log(ans.data);
-                        to_query.add(ans.data);
-                    });
-
-                    to_query.query();
-                });
-        }
-
-        /// Collection of Domains to query
-        class ToQuery {
-            constructor(domains) {
-                // array of Domain objects
-                this.domains = domains;
-            }
-
-            /// add a new domain entry via domain name
-            add(domain_name) {
-                let domain = new Domain(domain_name);
-                this.domains.push(domain);
-            }
-
-            /// query domains for LOC entries
-            query() {
-                console.log("query update ...");
-                this.domains.forEach( domain => {
-                    domain.query();
-                });
-            }
-        };
-
-        /// Location 
-
-        /// Domain
-        class Domain {
-            constructor(name) {
-                this.name = name;
-                this.entries = [];
-            }
-
-            /// query the LOC records of a domain
-            query() {
-                resolver.query(this.name, 'LOC')
-                    .then(response => {
-                        var id = 0;
-                        response.answers.forEach(ans => {
-                            // decode LOC wireformat package
-                            let loc = new LocDecoder(ans.data);
-
-                            // update marker on map
-                            this.update_marker(loc.latitude, loc.longitude, id);
-                            id++;
-                        });
-                    })
-                    .catch(err => console.error(err));
-            }
-
-            /// update marker on map
-            ///
-            /// the map ID is the answer number
-            update_marker(latitude, longitude, id) {
-                // check if marker exists
-                if (this.entries.length > id) {
-                    // update position
-                    let latLng = new L.LatLng(latitude, longitude);
-                    this.entries[id].setLatLng(latLng);
-
-                    // update popup text
-                    let popup_text = this.create_popup_text(latitude, longitude);
-                    this.entries[id].setPopupContent(popup_text);
-                } else {
-                    // set new map point
-                    this.create_marker(latitude, longitude);
-                }
-            }
-
-            /// create new map marker
-            create_marker(latitude, longitude) {
-                // set point of interest on map
-                let marker = L.marker([latitude, longitude]).addTo(map);
-
-                // set explanatory pop-up
-                let popup_text = this.create_popup_text(latitude, longitude);
-                marker.bindPopup(popup_text);
-
-                // add to entries
-                this.entries.push(marker);
-            }
-
-            /// create popup text
-            create_popup_text(latitude, longitude) {
-                let popup_text = "<b>" + this.name + "</b>";
-                popup_text += "<hr>Latitude: " + latitude;
-                popup_text += "<br>Longitude: " + longitude;
-                
-                return popup_text;
-            }
-
-            /// Trim location array to defined length
-            trim_entries(length) {
-                while(length > this.entries.length()) {
-                    this.entries.pop();
-                }
-            }
-        }
-
-        function timer_query() {
-            to_query.query();
-        }
-
-        // -------------------------------------------------------
-
         // set Domains object
-        var to_query = new ToQuery([]);
-        get_service_pointers("zembla.zenr.io");
-        setInterval(timer_query, 10000);
+        var map_loc_query = new MapLocQuery("zembla.zenr.io");
     </script>
 </body>
 </html>

--- a/demo/map.html
+++ b/demo/map.html
@@ -8,39 +8,7 @@
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin=""/>
     <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin=""></script>
 	<script src="https://cdn.jsdelivr.net/npm/dohjs@latest/dist/doh.min.js"></script>
-    <script>
-        /// Uint32 helper Class for byte conversion
-        class Uint32
-        {
-            constructor(Value) 
-            {
-                this.Number = new Uint32Array(1);
-                this.Number[0] = Value;
-            }
-            get Get() 
-            {
-                return this.Number[0];
-            }
-            set Set(newValue) 
-            {
-                this.Number[0] = newValue;
-            }
-        };
-
-        /// Convert u8 Byte array from network byte order (big-endian) to 32bit unsigned integer (little-endian)
-        function ntoh_Uint32 (Source_Byte_Array, Start_Position)
-        {
-            var Uint32_Num = new Uint32(0);
-            var Multiplier = 1;
-            for (let i = 3; i >= 0; i--)
-            {
-                Uint32_Num.Set = Uint32_Num.Get + Source_Byte_Array[Start_Position + i] * Multiplier;
-                Multiplier = Multiplier * 256;
-            }
-            return (Uint32_Num.Get);
-        }
-
-    </script>
+    <script src="dohjs_helpers.js"></script>
     <style>
 		html, body {
 			height: 100%;
@@ -114,6 +82,8 @@
             }
         };
 
+        /// Location 
+
         /// Domain
         class Domain {
             constructor(name) {
@@ -127,16 +97,11 @@
                     .then(response => {
                         var id = 0;
                         response.answers.forEach(ans => {
-                            // create latitude Uint32
-                            let latitude_raw = ntoh_Uint32(ans.data, 4);
-                            let latitude = (latitude_raw - 2147483648.0) / 3600000;
-
-                            // create longitude Uint32
-                            let longitude_raw = ntoh_Uint32(ans.data, 8);
-                            let longitude = (longitude_raw - 2147483648.0) / 3600000;
+                            // decode LOC wireformat package
+                            let loc = new LocDecoder(ans.data);
 
                             // update marker on map
-                            this.update_marker(latitude, longitude, id);
+                            this.update_marker(loc.latitude, loc.longitude, id);
                             id++;
                         });
                     })

--- a/demo/map.js
+++ b/demo/map.js
@@ -1,0 +1,205 @@
+/// Query Logic to show DNS LOC Records on a Map
+///
+/// The MapLocQuery Object will
+
+/// Map LOC Query Object
+class MapLocQuery {
+    /// construct this object with a domain to query
+    constructor(domain) {
+        this.domains = [];
+
+        this.add_domain(domain);
+    }
+
+    /// add and query domain
+    add_domain(domain) {
+        let service_domain = new LocServiceDomain(domain);
+        this.domains.push(service_domain);
+    }
+}
+
+/// Collection of ServicePtr to query
+class LocServiceDomain {
+    /// construct a new _loc service domain
+    constructor(loc_service_domain) {
+        // domain name
+        this.domain = loc_service_domain;
+        // array of ServicePtr objects
+        this.ptr_entries = [];
+
+        // query PTR records for domain
+        this.query_PTR();
+    }
+
+    /// query domain for service PTR records
+    query_PTR() {
+        // create _loc service FQDN
+        var query_domain = "_loc._udp." + this.domain;
+
+        console.log("query PTR records of " + query_domain);
+
+        resolver.query(query_domain, 'PTR')
+            .then(response => {
+                response.answers.forEach(ans => {
+                    console.log("PTR " +ans.data);
+
+                    // Create a pointer object and add it to the
+                    // service PTR list.
+                    let ptr = new ServicePtr(ans.data);
+                    this.ptr_entries.push(ptr);
+                });
+            });
+    }
+};
+
+/// Service PTR
+class ServicePtr {
+    constructor(ptr_domain) {
+        this.domain = ptr_domain;
+        this.txt = {};
+        this.srv_entries = [];
+
+        // query TXT records
+        this.query_TXT();
+
+        // query SRV records
+        this.query_SRV();
+    }
+
+    /// query TXT records of PTR domain
+    query_TXT() {
+        console.log("query_TXT()");
+
+        resolver.query(this.domain, 'TXT')
+            .then(response => {
+                var id = 0;
+                response.answers.forEach(ans => {
+                    console.log("TXT: " +ans.data);
+                    // TODO: pars TXT answer into key value object
+
+                    // fill in txt object
+                    this.txt.comment = ans.data;
+
+                    id++;
+                });
+            })
+            .catch(err => console.error(err));
+    }
+
+    /// query SRV records
+    query_SRV() {
+        console.log("query_SRV()");
+
+        resolver.query(this.domain, 'SRV')
+            .then(response => {
+                var id = 0;
+                response.answers.forEach(ans => {
+                    console.log("SRV: " +ans.data.target)
+
+                    // create an LOC records object for each record
+                    let loc_record = new LocRecords(ans.data.target, this.txt.comment);
+                    this.srv_entries.push(loc_record);
+                    id++;
+                });
+            })
+            .catch(err => console.error(err));
+    }
+
+    /// create LOC records object
+    create_loc_records(domain, info) {
+        let loc_record = new LocRecords(domain, info);
+        this.srv_entries.push(loc_record);
+    }
+}
+
+/// LOC SRV Records
+///
+/// On construction, a LOC records does the following things:
+///
+/// - query the FQDN for LOC records
+/// - place itself on the map
+/// - register a pop-up
+/// - set a timer to query the LOC record and update the location 
+///   every 10 seconds.
+class LocRecords {
+    constructor(domain, info) {
+        this.domain = domain;
+        this.info = info;
+        this.entries = [];
+
+        // query LOC records
+        this.query_LOC();
+
+        // set timer to re-query LOC records
+        setInterval(function() { this.query_LOC() }.bind(this), 10000);
+    }
+
+    /// construct a timeable function
+    /// queries LOC records of a domain
+    query_LOC() {
+        console.log("query_LOC() " +this.domain);
+
+        resolver.query(this.domain, 'LOC')
+            .then(response => {
+                var id = 0;
+                response.answers.forEach(ans => {
+                    // decode LOC wireformat package
+                    let loc = new LocDecoder(ans.data);
+
+                    // update marker on map
+                    this.update_marker(loc.latitude, loc.longitude, id);
+                    id++;
+                });
+            })
+            .catch(err => console.error(err));
+    }
+
+    /// create popup text
+    create_popup_text(latitude, longitude) {
+        let popup_text = "<b>" + this.domain + "</b>";
+        popup_text += "<hr>Latitude: " + latitude;
+        popup_text += "<br>Longitude: " + longitude;
+        popup_text += "<hr>" +this.info;
+        
+        return popup_text;
+    }
+
+    /// update marker on map
+    ///
+    /// the map ID is the answer number
+    update_marker(latitude, longitude, id) {
+        // check if marker exists
+        if (this.entries.length > id) {
+            // update position
+            let latLng = new L.LatLng(latitude, longitude);
+            this.entries[id].setLatLng(latLng);
+
+            // update popup text
+            let popup_text = this.create_popup_text(latitude, longitude);
+            this.entries[id].setPopupContent(popup_text);
+        } else {
+            // set new map point
+            this.create_marker(latitude, longitude);
+        }
+    }
+
+    /// create new map marker
+    create_marker(latitude, longitude) {
+        // set point of interest on map
+        let marker = L.marker([latitude, longitude]).addTo(map);
+
+        // set explanatory pop-up
+        let popup_text = this.create_popup_text(latitude, longitude);
+        marker.bindPopup(popup_text);
+
+        // add to entries
+        this.entries.push(marker);
+    }
+
+    /// Trim location array to defined length
+    trim_entries(length) {
+        while(length > this.entries.length()) {
+            this.entries.pop();
+        }
+    }
+}


### PR DESCRIPTION
The Map demo has the following structural upgrades:

- Javascript code moved to own specific files: `map.js` & `dohjs_helpers.js`
- new Object structure
  - reflecting the service discovery workflow:
    - service domains > PTRs > TXTs & SRVs > LOCs
  - structure multi-domain ready
  - LOC entries registering themselves for updating
- GUI changes: nicer pop-up descriptions: domain name, Locations & TXT comment

@adam-burns  Discussion & Suggestions about naming the objects would be appreciated :)