### PR TITLE
Check keystore key status against DNS

### DIFF
--- a/.github/workflows/gotest.yml
+++ b/.github/workflows/gotest.yml
@@ -12,6 +12,8 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: 1.22
+      - name: update apt pkgs
+        run: sudo apt-get update
       - name: install bind9 utilities
         run: sudo apt-get install bind9utils
       - name: Run tests

--- a/golang/sig0/keys_wasm.go
+++ b/golang/sig0/keys_wasm.go
@@ -43,8 +43,11 @@ func LoadKeyFile(keyfile string) (*Signer, error) {
 	return ParseKeyData(data.Key, data.Private)
 }
 
-// Lists keys by filename prefix compatible with nsupdate
-// (suffixed by .key & .private for public & private key files)
+// Returns all Keystore public keys and names as array of JSON objects
+// where
+//   Name: <filename prefix compatible with nsupdate>
+//   Key:  <public key in DNS RR format compatible with nsupdate>
+//
 func ListKeys(dir string) ([]storedKeyData, error) {
 	if dir != "." {
 		return nil, fmt.Errorf("directories not supported in wasm - use '.'")
@@ -89,6 +92,12 @@ func ListKeys(dir string) ([]storedKeyData, error) {
 }
 
 // Lists keys as JSON
+// Returns a filtered array of Keystore public keys and names as array of JSON objects
+// Keys returned possess a public key DNS RR name where searchDomain is contained.
+// where
+//   Name: <filename prefix compatible with nsupdate>
+//   Key:  <public key in DNS RR format compatible with nsupdate>
+//
 func ListKeysFiltered(dir, searchDomain string) ([]storedKeyData, error) {
 	allKeys, err := ListKeys(dir)
 	if err != nil {

--- a/golang/sig0/query.go
+++ b/golang/sig0/query.go
@@ -18,6 +18,10 @@ func QueryA(name string) (*dns.Msg, error) {
 	return QueryWithType(name, dns.TypeA)
 }
 
+func QueryKEY(name string) (*dns.Msg, error) {
+	return QueryWithType(name, dns.TypeKEY)
+}
+
 // uses ANY query type
 func QueryAny(name string) (*dns.Msg, error) {
 	return QueryWithType(name, dns.TypeANY)

--- a/golang/sig0/query.go
+++ b/golang/sig0/query.go
@@ -22,6 +22,10 @@ func QueryKEY(name string) (*dns.Msg, error) {
 	return QueryWithType(name, dns.TypeKEY)
 }
 
+func QueryPTR(name string) (*dns.Msg, error) {
+	return QueryWithType(name, dns.TypePTR)
+}
+
 // uses ANY query type
 func QueryAny(name string) (*dns.Msg, error) {
 	return QueryWithType(name, dns.TypeANY)

--- a/golang/wasm/pure.js
+++ b/golang/wasm/pure.js
@@ -112,7 +112,7 @@ async function requestKey() {
 	}).catch(err => alert(err.message))
 }
 
-function listKeys() {
+async function listKeys() {
 	const div = document.getElementById("existing-keys")
 	if (div.children.length > 0) {
 		div.removeChild(div.children[0])
@@ -121,9 +121,11 @@ function listKeys() {
 	const ul = document.createElement("ul")
 
 	const list = window.goFuncs.listKeys
+        const stat = window.goFuncs.checkKeyStatus
 	for (const k of list()) {
 		const li = document.createElement("li")
-		li.innerHTML = k.Name
+		// li.innerHTML = k.Name +" | " + await stat(k.Key.split("\t")[0], "zenr.io", "doh.zenr.io")
+		li.innerHTML = k.Name +" | " + await stat(k.Name, "zenr.io", "doh.zenr.io")
 
 		ul.appendChild(li)
 	}
@@ -131,6 +133,8 @@ function listKeys() {
 
 	return
 }
+
+
 
 // getKeysForDomain()
 //	list keys in the keystore

--- a/golang/wasm/pure.js
+++ b/golang/wasm/pure.js
@@ -112,7 +112,28 @@ async function requestKey() {
 	}).catch(err => alert(err.message))
 }
 
-async function listKeys() {
+function listKeys() {
+	const div = document.getElementById("existing-keys")
+	if (div.children.length > 0) {
+		div.removeChild(div.children[0])
+	}
+
+	const ul = document.createElement("ul")
+
+	const list = window.goFuncs.listKeys
+
+	for (const k of list()) {
+		const li = document.createElement("li")
+		li.innerHTML = k.Name
+
+		ul.appendChild(li)
+	}
+	div.appendChild(ul)
+
+	return
+}
+
+async function listKeysWithStatus() {
 	const div = document.getElementById("existing-keys")
 	if (div.children.length > 0) {
 		div.removeChild(div.children[0])
@@ -124,8 +145,8 @@ async function listKeys() {
         const stat = window.goFuncs.checkKeyStatus
 	for (const k of list()) {
 		const li = document.createElement("li")
-		// li.innerHTML = k.Name +" | " + await stat(k.Key.split("\t")[0], "zenr.io", "doh.zenr.io")
-		li.innerHTML = k.Name +" | " + await stat(k.Name, "zenr.io", "doh.zenr.io")
+		const s = await stat(k.Name, "zenr.io", "doh.zenr.io")
+		li.innerHTML = k.Name +" | Key Exists in DNS: " + s.KeyRRExists +" | Key Request Queued: " + s.QueuePTRExists
 
 		ul.appendChild(li)
 	}

--- a/golang/wasm/wasm_exec.html
+++ b/golang/wasm/wasm_exec.html
@@ -9,6 +9,7 @@
 		<h2>DNS Keys</h2>
       		<h3>List</h3>
      		<button onclick="listKeys()">Update</button>
+     		<button onclick="listKeysWithStatus()">Update with Status</button>
 		<div id="existing-keys"></div>
 
 

--- a/golang/wasm/wasm_exec.html
+++ b/golang/wasm/wasm_exec.html
@@ -7,9 +7,9 @@
 	</head>
 	<body>
 		<h2>DNS Keys</h2>
-      		<h3>List</h3>
+      		<h3>List Keystore</h3>
      		<button onclick="listKeys()">Update</button>
-     		<button onclick="listKeysWithStatus()">Update with Status</button>
+     		<button onclick="listKeysWithStatus()">Update with DNS Status</button>
 		<div id="existing-keys"></div>
 
 

--- a/golang/wasm/wrapper_js.go
+++ b/golang/wasm/wrapper_js.go
@@ -127,7 +127,7 @@ func checkKeyStatus(_ js.Value, args []js.Value) any {
 
 			switch answerKeyRR.Rcode {
 			case dns.RcodeSuccess:
-				keyRRExists = false
+				// keyRRExists = false
 				for _, rr := range answerKeyRR.Answer {
 					answerKey, ok := rr.(*dns.KEY)
 					if !ok {
@@ -146,7 +146,7 @@ func checkKeyStatus(_ js.Value, args []js.Value) any {
 				}
 
 			case dns.RcodeNameError:
-				keyRRExists = false
+				// keyRRExists = false
 
 			default:
 				err = fmt.Errorf("did not get KEY RR success answer\n:%#v", answerKeyRR)
@@ -174,7 +174,7 @@ func checkKeyStatus(_ js.Value, args []js.Value) any {
 
 			switch answerSignalPtr.Rcode {
 			case dns.RcodeSuccess:
-				signalPTRExists = false
+				// signalPTRExists = false
 				for _, rr := range answerSignalPtr.Answer {
 					ptrRR, ok := rr.(*dns.PTR)
 					if !ok {
@@ -190,7 +190,7 @@ func checkKeyStatus(_ js.Value, args []js.Value) any {
 				}
 
 			case dns.RcodeNameError:
-				signalPTRExists = false
+				// signalPTRExists = false
 
 			default:
 				err = fmt.Errorf("did not get PTR RR success answer\n:%#v", answerKeyRR)

--- a/golang/wasm/wrapper_js.go
+++ b/golang/wasm/wrapper_js.go
@@ -155,7 +155,8 @@ func checkKeyStatus(_ js.Value, args []js.Value) any {
 
 			// query for submission queue PTR at _signal.zone and submission queue KEY under ._signal.zone
 			signalPtrRRName := sig0.SignalSubzonePrefix + "." + zone
-			signalKeyRRName := strings.TrimSuffix(keyFqdn, "."+zone) + "."
+			signalKeyRRName := strings.TrimSuffix(keyFqdn, "."+zone) + "." + 
+				sig0.SignalSubzonePrefix + "." + zone
 
 			// construct query for _signal.zone PTR RRset
 			msgSigPtr, err := sig0.QueryPTR(signalPtrRRName)

--- a/golang/wasm/wrapper_js.go
+++ b/golang/wasm/wrapper_js.go
@@ -117,7 +117,6 @@ func checkKeyStatus(_ js.Value, args []js.Value) any {
 				reject.Invoke(jsErr(err))
 				return
 			}
-			// spew.Dump(msgKey)
 
 			answerKeyRR, err := sig0.SendDOHQuery(dohServer, msgKey)
 			if err != nil {
@@ -127,7 +126,6 @@ func checkKeyStatus(_ js.Value, args []js.Value) any {
 
 			switch answerKeyRR.Rcode {
 			case dns.RcodeSuccess:
-				// keyRRExists = false
 				for _, rr := range answerKeyRR.Answer {
 					answerKey, ok := rr.(*dns.KEY)
 					if !ok {
@@ -146,7 +144,6 @@ func checkKeyStatus(_ js.Value, args []js.Value) any {
 				}
 
 			case dns.RcodeNameError:
-				// keyRRExists = false
 
 			default:
 				err = fmt.Errorf("did not get KEY RR success answer\n:%#v", answerKeyRR)
@@ -174,7 +171,6 @@ func checkKeyStatus(_ js.Value, args []js.Value) any {
 
 			switch answerSignalPtr.Rcode {
 			case dns.RcodeSuccess:
-				// signalPTRExists = false
 				for _, rr := range answerSignalPtr.Answer {
 					ptrRR, ok := rr.(*dns.PTR)
 					if !ok {
@@ -190,7 +186,6 @@ func checkKeyStatus(_ js.Value, args []js.Value) any {
 				}
 
 			case dns.RcodeNameError:
-				// signalPTRExists = false
 
 			default:
 				err = fmt.Errorf("did not get PTR RR success answer\n:%#v", answerKeyRR)

--- a/golang/wasm/wrapper_js.go
+++ b/golang/wasm/wrapper_js.go
@@ -110,8 +110,6 @@ func checkKeyStatus(_ js.Value, args []js.Value) any {
 			// construct query for KEY RRSet at FQDN keyname
 			// TODO BUG cannot yet pass RData via QueryKEY() for exact RR
 			// as SendDOHQuery errors with dns: bad rdata
-			// var keyRRStatus string
-			// var signalPTRStatus string
 			var signalPTRExists bool
 			var keyRRExists bool
 			msgKey, err := sig0.QueryKEY(keyFqdn)

--- a/golang/wasm/wrapper_js.go
+++ b/golang/wasm/wrapper_js.go
@@ -13,12 +13,6 @@ import (
 	"github.com/NetworkCommons/sig0namectl/sig0"
 )
 
-var (
-        SignalSubzonePrefix = "_signal"
-        DefaultTTL          = 60
-        DefaultDOHResolver  = "dns.quad9.net"
-)
-
 // Go <-> JS bridging setup
 // ========================
 
@@ -163,8 +157,8 @@ func checkKeyStatus(_ js.Value, args []js.Value) any {
 			}
 
 			// query for submission queue PTR at _signal.zone and submission queue KEY under ._signal.zone
-			signalPtrRRName := SignalSubzonePrefix + "." + zone
-			signalKeyRRName := strings.TrimSuffix(keyFqdn, "." + zone) + "." + SignalSubzonePrefix + "." + zone
+			signalPtrRRName := sig0.SignalSubzonePrefix + "." + zone
+			signalKeyRRName := strings.TrimSuffix(keyFqdn, "." + zone) + "." + sig0.SignalSubzonePrefix + "." + zone
 
 			// log.Println("*** keyFqdn: ", keyFqdn)
 			// log.Println("*** zone: ", zone)


### PR DESCRIPTION
Exposes new function via wasm: 

`checkKeyStatus()`

- expects 3 arguments: 
  - keystore keyname (as filename prefix)
  - zone 
  - dohServer to perform queries against
- returns JSON of the form:
```
 {
    KeyRRExists: true/false
    QueuePTRExists: true/false
  }
```
where:
`KeyRRExists` indicates whether the keystore key's public key RR is present in the DNS
`QueuePTRExists` indicates whether the new key request for the key is still pending (whether successful or not, all key request DNS records are deleted after processing)

- If `KeyRRExists` is true, the key in the keystore is active (regardless of ` QueuePTRExists` state).
- If `KeyRRExists` is false and `QueuePTRExists` is true, the new key request for the keystore key has not yet been processed.
- If `KeyRRExists` is false and `QueuePTRExists` is false, either the original new key request for the keystore key was unsuccessful, or the key has since been deleted since a successful new key request processing.
